### PR TITLE
Fix various catkin build issues

### DIFF
--- a/sr_dynamic_time_warping/CMakeLists.txt
+++ b/sr_dynamic_time_warping/CMakeLists.txt
@@ -1,16 +1,12 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(sr_dynamic_time_warping)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
-find_package(cmake_modules  REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   rostest
 )
 
 ## System dependencies are found with CMake's conventions
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 ## Uncomment this if the package has a setup.py. This macro ensures
 ## modules and global scripts declared therein get installed
@@ -90,7 +86,7 @@ catkin_package(
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(include)
-include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )

--- a/sr_dynamic_time_warping/CMakeLists.txt
+++ b/sr_dynamic_time_warping/CMakeLists.txt
@@ -1,9 +1,7 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(sr_dynamic_time_warping)
 
-find_package(catkin REQUIRED COMPONENTS
-  rostest
-)
+find_package(catkin REQUIRED COMPONENTS)
 
 ## System dependencies are found with CMake's conventions
 find_package(Eigen3 REQUIRED)
@@ -149,6 +147,7 @@ install(DIRECTORY include/${PROJECT_NAME}/
 
 ## Add gtest based cpp test target and link libraries
 if (CATKIN_ENABLE_TESTING)
+  find_package(rostest REQUIRED)
   catkin_add_gtest(dtw-test test/test_dtw.cpp)
   if(TARGET dtw-test)
      target_link_libraries(dtw-test dtw)

--- a/sr_dynamic_time_warping/include/sr_dynamic_time_warping/dtw.hpp
+++ b/sr_dynamic_time_warping/include/sr_dynamic_time_warping/dtw.hpp
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <ros/ros.h>
 #include "sr_dynamic_time_warping/vector_dtw.hpp"
 #include <vector>
 

--- a/sr_dynamic_time_warping/package.xml
+++ b/sr_dynamic_time_warping/package.xml
@@ -20,7 +20,7 @@
   <author email="yi@shadowrobot.com">Yi Li</author>
   <author email="ugo@shadowrobot.com">Ugo Cupcic</author>
 
-  <test_depend>gtest</test_depend>
+  <test_depend>rostest</test_depend>
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>eigen</build_depend>

--- a/sr_dynamic_time_warping/package.xml
+++ b/sr_dynamic_time_warping/package.xml
@@ -23,7 +23,7 @@
   <test_depend>gtest</test_depend>
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>cmake_modules</build_depend>
+  <build_depend>eigen</build_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/sr_dynamic_time_warping/test/test_dtw.cpp
+++ b/sr_dynamic_time_warping/test/test_dtw.cpp
@@ -16,8 +16,6 @@
 
 #include <algorithm>
 #include <vector>
-#include <ros/ros.h>
-#include <ros/package.h>
 #include <gtest/gtest.h>
 #include <cmath>
 

--- a/sr_interpolation/CMakeLists.txt
+++ b/sr_interpolation/CMakeLists.txt
@@ -5,7 +5,6 @@ project(sr_interpolation)
 add_compile_options(-std=c++17)
 
 find_package(catkin REQUIRED COMPONENTS
-  rostest
   roscpp
 )
 

--- a/sr_interpolation/CMakeLists.txt
+++ b/sr_interpolation/CMakeLists.txt
@@ -4,17 +4,13 @@ project(sr_interpolation)
 ## Compile as C++11, supported in ROS Kinetic and newer
 add_compile_options(-std=c++17)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
-find_package(cmake_modules  REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   rostest
   roscpp
 )
 
 ## System dependencies are found with CMake's conventions
-find_package(Eigen REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 
@@ -100,7 +96,7 @@ target_link_libraries(sr_interpolation ${catkin_LIBRARIES})
 ## Specify additional locations of header files
 ## Your package locations should be listed before other locations
 include_directories(include)
-include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
+include_directories(SYSTEM ${EIGEN3_INCLUDE_DIRS})
 include_directories(
   ${catkin_INCLUDE_DIRS}
 )

--- a/sr_interpolation/package.xml
+++ b/sr_interpolation/package.xml
@@ -17,7 +17,7 @@
   <test_depend>gtest</test_depend>
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend>cmake_modules</build_depend>
+  <build_depend>eigen</build_depend>
   <build_depend>roscpp</build_depend>
   <run_depend>roscpp</run_depend>
 

--- a/sr_interpolation/package.xml
+++ b/sr_interpolation/package.xml
@@ -14,7 +14,6 @@
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>LGPLv3</license>
 
-  <test_depend>gtest</test_depend>
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>eigen</build_depend>


### PR DESCRIPTION
Fixes various issues in catkin build config (see individual commit messages for details). All issues were found by `catkin_lint`.
See https://github.com/shadow-robot/ros_ethercat/pull/116#issue-1016582683 for more details.
