### PR TITLE
setup.py: Use setuptools instead of distutils

### DIFF
--- a/sr_system_info/setup.py
+++ b/sr_system_info/setup.py
@@ -1,7 +1,7 @@
 # ! DO NOT MANUALLY INVOKE THIS setup.py, USE CATKIN INSTEAD
 
 from __future__ import absolute_import
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml


### PR DESCRIPTION
See http://wiki.ros.org/noetic/Migration#Setuptools_instead_of_Distutils
